### PR TITLE
implement PaymentStatusCommunicator (update state via webhooks)

### DIFF
--- a/app/controllers/spree/global_collect_checkouts_controller.rb
+++ b/app/controllers/spree/global_collect_checkouts_controller.rb
@@ -13,31 +13,13 @@ module Spree
       if @payment.present?
         @payment.complete! ? render_ok : render_nok
       else
-        Order.transaction do
-          order = Order.find(params['ORDERID'])
-
-          global_collect_checkout = GlobalCollectCheckout.create(
-            order_number:   order.global_collect_number,
-            order:          order,
-            user_id:        order.user_id,
-            payment_method_id: params[:global_collect][:payment_method_id],
+        Spree::Order.transaction do
+          @order.payments.create!(
+            source: @global_collect_checkout,
+            amount: @order.total, payment_method: @global_collect_checkout.payment_method
           )
 
-          order.payments.create!(
-            source: global_collect_checkout,
-            amount: order.total,
-            payment_method_id: global_collect_checkout.payment_method_id,
-          )
-
-          order.next
-
-          if order.complete?
-            render_ok
-          else
-            # this will let webhooks continue trigger us until the
-            # payment is flagged as completed
-            render_nok
-          end
+          @order.next || fail(ActiveRecord::Rollback)
         end
       end
     end
@@ -51,15 +33,15 @@ module Spree
     end
 
     def load_global_collect_checkout
-      @global_collect_checkout = GlobalCollectCheckout.find_by_order_number(params['ORDERID'])
+      @global_collect_checkout = GlobalCollectCheckout.find_by_order_number!(params['ORDERID'])
     end
 
     def load_payment
-      @payment = @global_collect_checkout.try(:payment)
+      @payment = @global_collect_checkout.payment
     end
 
     def load_order
-      @order = @global_collect_checkout.try(:order)
+      @order = @global_collect_checkout.order
     end
 
     def render_ok

--- a/app/controllers/spree/global_collect_checkouts_controller.rb
+++ b/app/controllers/spree/global_collect_checkouts_controller.rb
@@ -10,7 +10,7 @@ module Spree
       return render(nothing: true) unless status_successful?
       return render_ok             if @payment.try(:completed?)
 
-      if @payment.present? && @payment.complete!
+      if @payment.present? && @payment.can_complete? && @payment.complete!
         render_ok
       else
         render_nok

--- a/app/controllers/spree/global_collect_checkouts_controller.rb
+++ b/app/controllers/spree/global_collect_checkouts_controller.rb
@@ -48,8 +48,13 @@ module Spree
     def status_successful?
       return false unless params['STATUSID'].present?
 
-      # Successful if STATUSID is READY (800) or PAID (1000)
-      params['STATUSID'].to_i == 800 || params['STATUSID'].to_i == 1000
+      success_status_codes = [
+        800,  # READY
+        1000, # PAID
+        1050, # COLLECTED (used by Sofort)
+      ]
+
+      success_status_codes.include?(params['STATUSID'].to_i)
     end
 
     # A webhook is received from GlobalCollect which we don't have payments for.

--- a/app/controllers/spree/global_collect_checkouts_controller.rb
+++ b/app/controllers/spree/global_collect_checkouts_controller.rb
@@ -19,7 +19,15 @@ module Spree
             amount: @order.total, payment_method: @global_collect_checkout.payment_method
           )
 
-          @order.next || fail(ActiveRecord::Rollback)
+          @order.next
+
+          if @order.complete?
+            render_ok
+          else
+            # this will let webhooks continue trigger us until the
+            # payment is flagged as completed
+            render_nok
+          end
         end
       end
     end

--- a/app/models/spree/global_collect_checkout.rb
+++ b/app/models/spree/global_collect_checkout.rb
@@ -54,6 +54,7 @@ module Spree
         attempt_id:           response[:attemptid],
         gc_payment_method_id: response[:paymentmethodid],
         payment_reference:    response[:paymentreference],
+        merchant_reference:   response[:merchantreference],
         cc_last_four_digits:  response[:creditcardnumber],
         expiry_date:          response[:expirydate]
       )

--- a/app/models/spree/global_collect_checkout.rb
+++ b/app/models/spree/global_collect_checkout.rb
@@ -1,6 +1,8 @@
 module Spree
   class GlobalCollectCheckout < ActiveRecord::Base
     belongs_to :order, class_name: 'Spree::Order'
+    belongs_to :user, class_name: Spree.user_class.to_s
+    belongs_to :payment_method, class_name: 'Spree::PaymentMethod'
     has_one :payment, class_name: 'Spree::Payment', as: :source
 
     scope :with_payment_profile, -> { where('profile_token IS NOT NULL') }

--- a/app/models/spree/global_collect_checkout.rb
+++ b/app/models/spree/global_collect_checkout.rb
@@ -1,5 +1,6 @@
 module Spree
   class GlobalCollectCheckout < ActiveRecord::Base
+    belongs_to :order, class_name: 'Spree::Order'
     has_one :payment, class_name: 'Spree::Payment', as: :source
 
     scope :with_payment_profile, -> { where('profile_token IS NOT NULL') }

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -7,8 +7,12 @@ Spree::Order.class_eval do
            :global_collect_city, :zipcode, :state_text, :global_collect_street,
            to: :ship_address, allow_nil: true, prefix: true
 
-  def global_collect_number
+  def self.generate_global_collect_number(number)
     number.gsub(/[^0-9]/i, '')
+  end
+
+  def global_collect_number
+    self.class.generate_global_collect_number(number)
   end
 
   def global_collect_total

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -7,6 +7,8 @@ Spree::Order.class_eval do
            :global_collect_city, :zipcode, :state_text, :global_collect_street,
            to: :ship_address, allow_nil: true, prefix: true
 
+  has_many :global_collect_checkouts
+
   def self.generate_global_collect_number(number)
     number.gsub(/[^0-9]/i, '')
   end

--- a/db/migrate/20150915075841_add_merchant_reference_to_spree_global_collect_checkout.rb
+++ b/db/migrate/20150915075841_add_merchant_reference_to_spree_global_collect_checkout.rb
@@ -1,0 +1,5 @@
+class AddMerchantReferenceToSpreeGlobalCollectCheckout < ActiveRecord::Migration
+  def change
+    add_column :spree_global_collect_checkouts, :merchant_reference, :string
+  end
+end

--- a/db/migrate/20151006134906_add_spree_order_id_to_spree_global_collect_checkout.rb
+++ b/db/migrate/20151006134906_add_spree_order_id_to_spree_global_collect_checkout.rb
@@ -1,0 +1,5 @@
+class AddSpreeOrderIdToSpreeGlobalCollectCheckout < ActiveRecord::Migration
+  def change
+    add_column :spree_global_collect_checkouts, :order_id, :integer
+  end
+end


### PR DESCRIPTION
When visiting the `confirm` action there was a risk of creating multiple payments that resulted in capture problems.

This will fix this by preventing a user to create multiple payments when visiting the confirm action more than once. It is done by saving the `merchantreference` field and checking if there is already a payment with that merchant reference.
